### PR TITLE
Released-current doesn't list all the available amis


### DIFF
--- a/lib/ubuntu_ami.rb
+++ b/lib/ubuntu_ami.rb
@@ -58,7 +58,7 @@ class Ubuntu
   # === Returns
   # String:: The full URL to the released AMIs.
   def url
-    "http://uec-images.ubuntu.com/query/#{release_name}/server/released.current.txt"
+    "http://uec-images.ubuntu.com/query/#{release_name}/server/released.txt"
   end
 
   # Reads the URL for processing.


### PR DESCRIPTION
Saw this today trying to request an instance store amd64 in us-east-1.   Looks like if you use the full released url it will return back the full list of amis

Here:  https://gist.github.com/d488c4bb08ea2986de31
