### PR TITLE
Don't ship the readme in the gem + bump to 0.4.2

### DIFF
--- a/lib/ubuntu_ami/version.rb
+++ b/lib/ubuntu_ami/version.rb
@@ -17,6 +17,6 @@
 
 class Ubuntu
   class Ami
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end

--- a/ubuntu_ami.gemspec
+++ b/ubuntu_ami.gemspec
@@ -3,14 +3,12 @@ require 'ubuntu_ami/version'
 Gem::Specification.new do |s|
   s.name = 'ubuntu_ami'
   s.version = Ubuntu::Ami::VERSION
-  s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
-  s.extra_rdoc_files = ["README.md", "LICENSE"]
   s.summary = "Retrieves AMI information from Canonical's Ubuntu release list."
   s.description = s.summary + "Also provides a knife plugin to retrieve the list."
   s.author = "Joshua Timberman"
-  s.email = "joshua@opscode.com"
-  s.homepage = "http://github.com/jtimberman/ubuntu_ami"
+  s.email = "joshua@chef.io"
+  s.homepage = "https://github.com/jtimberman/ubuntu_ami"
   s.require_path = 'lib'
-  s.files = %w(LICENSE README.md) + Dir.glob("lib/**/*")
+  s.files = %w(LICENSE) + Dir.glob("lib/**/*")
+  s.license = "Apache-2.0"
 end


### PR DESCRIPTION
This helps us slim Chef-DK a *tiny* bit