### PR TITLE
Update the URL to query UEC images

### DIFF
--- a/lib/ubuntu_ami.rb
+++ b/lib/ubuntu_ami.rb
@@ -58,7 +58,7 @@ class Ubuntu
   # === Returns
   # String:: The full URL to the released AMIs.
   def url
-    "http://uec-images.ubuntu.com/query/#{release_name}/server/released.current.txt"
+    "http://cloud-images.ubuntu.com/query/#{release_name}/server/released.current.txt"
   end
 
   # Reads the URL for processing.

--- a/lib/ubuntu_ami/version.rb
+++ b/lib/ubuntu_ami/version.rb
@@ -17,6 +17,6 @@
 
 class Ubuntu
   class Ami
-    VERSION = '0.4.3'
+    VERSION = '0.4.4'
   end
 end


### PR DESCRIPTION
After years of faithful service we ran into this today:

`Failed to open TCP connection to uec-images.ubuntu.com:80 (getaddrinfo: Name or service not known) (SocketError)`

I'm not sure if this is a temporary DNS issue, but https://help.ubuntu.com/community/UEC/Images shows the query url as http://cloud-images.ubuntu.com/query. Thanks!